### PR TITLE
Fix concurrency bug in build cache

### DIFF
--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
@@ -172,7 +172,7 @@ public class BuildCache {
         }
         Set<String> downstreamBuilds =
             downstreamBuildCache.computeIfAbsent(
-                upstreamBuild.getExternalizableId(), v -> new HashSet<>());
+                upstreamBuild.getExternalizableId(), v -> ConcurrentHashMap.newKeySet());
         downstreamBuilds.add(downstreamRun.getExternalizableId());
       }
     }


### PR DESCRIPTION
In rare situations concurrent modification exceptions was thrown when one thread was retrieving builds and another was starting a new build.
This change fixes the problem by using a ConcurrentHashMap as the underlying storage for the downstream build cache.

I'm not 100% sure what impact this will have on performance, but my gut feeling tells me that there will be a smal performance degrade.