### PR TITLE
[JENKINS-60504] Improved resilience against NPE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
       <name>Gustaf Lundh</name>
       <email>gustaf.lundh@axis.com</email>
     </developer>
+    <developer>
+      <id>jonsten</id>
+      <name>Jon Sten</name>
+      <email>jon.sten@axis.com</email>
+    </developer>
   </developers>
 
   <licenses>

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
@@ -74,7 +74,7 @@ public class BuildCache {
         .anyMatch(
             cause ->
                 cause instanceof UpstreamCause
-                    && ((UpstreamCause) cause).getUpstreamRun().equals(run));
+                    && run.equals(((UpstreamCause) cause).getUpstreamRun()));
   }
 
   /**

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
@@ -70,6 +70,9 @@ public class BuildCache {
   }
 
   private static boolean isQueueItemCausedBy(Queue.Item item, Run run) {
+    if (run == null || item == null) {
+      return false;
+    }
     return item.getCauses().stream()
         .anyMatch(
             cause ->


### PR DESCRIPTION
We can be fairly certain that run never is null, by rearranging the equals call we protect against null pointers.
This is a potential fix for JENKINS-60504.