### PR TITLE
Allow the cache to build in the background

### DIFF
--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
@@ -2,6 +2,7 @@ package com.axis.system.jenkins.plugins.downstream.cache;
 
 import static hudson.init.InitMilestone.JOB_LOADED;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.init.Initializer;
 import hudson.init.Terminator;
 import hudson.model.AbstractItem;
@@ -43,6 +44,8 @@ public class BuildCache {
 
   private final ConcurrentHashMap<String, Set<String>> downstreamBuildCache =
       new ConcurrentHashMap<>();
+
+  @SuppressFBWarnings("IS2_INCONSISTENT_SYNC")
   private ExecutorService workerThreadPool;
   private AtomicBoolean isCacheRefreshing = new AtomicBoolean(true);
   private Timer gcTimer;
@@ -224,14 +227,12 @@ public class BuildCache {
     Logger.info("GC completed!");
   }
 
-  public synchronized void setupGarbageCollector() {
+  public void setupGarbageCollector() {
     Logger.info("Setting up GC scheduling");
-    if (gcTimer == null) {
-      gcTimer = new Timer();
-    } else {
+    if (gcTimer != null) {
       gcTimer.cancel();
-      gcTimer = new Timer();
     }
+    gcTimer = new Timer();
     gcTimer.scheduleAtFixedRate(
         new TimerTask() {
           @Override
@@ -243,7 +244,7 @@ public class BuildCache {
         GC_INTERVAL);
   }
 
-  public synchronized void stopGarbageCollector() {
+  public void stopGarbageCollector() {
     Logger.info("Stopping GC scheduling");
     if (gcTimer != null) {
       gcTimer.cancel();

--- a/src/test/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCacheTest.java
+++ b/src/test/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCacheTest.java
@@ -33,7 +33,7 @@ public class BuildCacheTest {
     Run upstreamBuild = upstreamProject.scheduleBuild2(0).get();
     Run downstreamBuild =
         downstreamProject.scheduleBuild2(0, new Cause.UpstreamCause(upstreamBuild)).get();
-    BuildCache.getCache().reloadCache();
+    BuildCache.getCache().scheduleReloadCache().get();
     BuildCache cache = BuildCache.getCache();
     assertThat(
         "Wrong number of expected builds in cache",
@@ -81,7 +81,7 @@ public class BuildCacheTest {
         downstreamProjectA.scheduleBuild2(0, new Cause.UpstreamCause(upstreamBuild)).get();
     Run downstreamBuildB =
         downstreamProjectB.scheduleBuild2(0, new Cause.UpstreamCause(upstreamBuild)).get();
-    BuildCache.getCache().reloadCache();
+    BuildCache.getCache().scheduleReloadCache().get();
     BuildCache cache = BuildCache.getCache();
     assertThat(
         "Wrong number of expected builds in cache",


### PR DESCRIPTION
A single thread worker pool is introduced, allowing workloads like
cache reloading and garbage collecting to be executed in FIFO-order.

By building the cache in the background, it allows for Jenkins
installations with a large amount of builds to serve the UI much quicker
after a restart.

On one test server with approx. 60k builds, the time from restart to UI
went from 4 minutes down to roughly 30 seconds.

While the cache is building the new method BuildCache.isCacheRefreshing()
will return true. Clients that depends on this plug-in needs to handle
this case accordingly.