### PR TITLE
Improve performance of getDownstreamQueueItems()

### DIFF
--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
@@ -89,7 +89,7 @@ public class BuildCache {
         .anyMatch(
             cause ->
                 cause instanceof UpstreamCause
-                    && run.equals(((UpstreamCause) cause).getUpstreamRun()));
+                    && ((UpstreamCause) cause).pointsTo(run));
   }
 
   /**


### PR DESCRIPTION
On instances with a long build queues this method started to take unreasonably long time to compute downstream queue items. By switching to UpstreamCause#pointsTo() we save a lot of time since Jenkins don't need to resolve the actual Job and Run objects.

On a local master I had the following setup:
1 base job which triggered 500 child job, each child job did in turn trigger another job which ended up on the queue (and didn't start building). On the queue there was a total of 1500 jobs.
Without this fix average time to compute buildFlow.groovy was around 5 seconds. With this fix it goes down to an average 0.4 seconds. So a tenth compared to before.

The execution time is still quite high and there are more things that can be done. The complexity is O(n*m) where n is the number of child builds (of the job/build being rendered) and m is the queue length. For example, if the queue grows over 5000 the render time for my example above goes above 1 second. One thing that can be done to improve performance is use classic for-each loops instead of streams, or more drastically, introduce a cache for the queue. E.g. implement a queue listener which maintenance a map between run and queue items.