### PR TITLE
Add pipeline step for getting downstream builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.6
+* **Feature**: New pipeline step, downstreamBuilds, which provides downstream builds for a given build
+
 ## v1.5.2
 * Fix: Queue related performance fixes
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.37</version>
+    <version>3.47</version>
     <relativePath />
   </parent>
 
@@ -48,8 +48,54 @@
     <tag>HEAD</tag>
   </scm>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+      <version>2.19</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <version>2.22</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.26</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>2.40</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>pipeline-build-step</artifactId>
+      <version>2.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-support</artifactId>
+      <version>2.22</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <properties>
-    <jenkins.version>2.73.3</jenkins.version>
+    <jenkins.version>2.121.1</jenkins.version>
     <java.level>8</java.level>
     <jenkins-test-harness.version>2.38</jenkins-test-harness.version>
     <!-- Need this due to commit message rules (default prefix start with non-alphanumeric char): -->

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
@@ -85,11 +85,9 @@ public class BuildCache {
     if (run == null || item == null) {
       return false;
     }
-    return item.getCauses().stream()
-        .anyMatch(
-            cause ->
-                cause instanceof UpstreamCause
-                    && ((UpstreamCause) cause).pointsTo(run));
+    return item.getCauses()
+        .stream()
+        .anyMatch(cause -> cause instanceof UpstreamCause && ((UpstreamCause) cause).pointsTo(run));
   }
 
   /**

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/pipeline/DownstreamBuildsStep.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/pipeline/DownstreamBuildsStep.java
@@ -1,0 +1,71 @@
+package com.axis.system.jenkins.plugins.downstream.cache.pipeline;
+
+import com.axis.system.jenkins.plugins.downstream.cache.BuildCache;
+import hudson.Extension;
+import hudson.model.Run;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.jenkinsci.plugins.workflow.steps.*;
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+public class DownstreamBuildsStep extends Step {
+
+  @DataBoundSetter private RunWrapper run;
+
+  @DataBoundConstructor
+  public DownstreamBuildsStep() {}
+
+  @Override
+  public StepExecution start(StepContext stepContext) throws Exception {
+    if (run == null) {
+      run = new RunWrapper(stepContext.get(Run.class), true);
+    }
+    return new Execution(run, stepContext);
+  }
+
+  private static class Execution extends SynchronousNonBlockingStepExecution<List<RunWrapper>> {
+    private final RunWrapper run;
+
+    protected Execution(@Nonnull RunWrapper run, @Nonnull StepContext context) {
+      super(context);
+      this.run = run;
+    }
+
+    @Override
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+        value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+        justification = "rawBuild can't be null singe getDownstreamBuilds filter out null elements")
+    protected List<RunWrapper> run() throws Exception {
+      Set<Run> rawBuilds = BuildCache.getCache().getDownstreamBuilds(run.getRawBuild());
+      List<RunWrapper> builds = new ArrayList<>();
+      for (Run rawBuild : rawBuilds) {
+        builds.add(new RunWrapper(rawBuild, false));
+      }
+      return builds;
+    }
+  }
+
+  @Extension(optional = true)
+  public static final class DescriptorImpl extends StepDescriptor {
+
+    @Override
+    public Set<? extends Class<?>> getRequiredContext() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public String getFunctionName() {
+      return "downstreamBuilds";
+    }
+
+    @Override
+    public String getDisplayName() {
+      return "Provide list of downstream builds";
+    }
+  }
+}

--- a/src/test/java/com/axis/system/jenkins/plugins/downstream/cache/pipeline/DownstreamBuildsStepTest.java
+++ b/src/test/java/com/axis/system/jenkins/plugins/downstream/cache/pipeline/DownstreamBuildsStepTest.java
@@ -1,0 +1,69 @@
+package com.axis.system.jenkins.plugins.downstream.cache.pipeline;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/** Test downstream pipeline step */
+public class DownstreamBuildsStepTest {
+  @Rule public JenkinsRule j = new JenkinsRule();
+
+  @Test
+  public void noDownstreamBuilds() throws Exception {
+    WorkflowJob parent = j.createProject(WorkflowJob.class);
+    parent.setDefinition(new CpsFlowDefinition("assert downstreamBuilds() == []", true));
+    j.buildAndAssertSuccess(parent);
+  }
+
+  @Test
+  public void ongoingDownstreams() throws Exception {
+    WorkflowJob child1 = j.createProject(WorkflowJob.class, "child1");
+    child1.setDefinition(
+        new CpsFlowDefinition(
+            "org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep.success('waitForChild1/1', null);"
+                + "semaphore 'waitForParent'",
+            false));
+    WorkflowJob child2 = j.createProject(WorkflowJob.class, "child2");
+    child2.setDefinition(
+        new CpsFlowDefinition(
+            "org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep.success('waitForChild2/1', null);"
+                + "semaphore 'waitForParent'",
+            false));
+
+    WorkflowJob parent = j.createProject(WorkflowJob.class);
+    parent.setDefinition(
+        new CpsFlowDefinition(
+            "build job:'child1', wait:false;"
+                + "build job:'child2', wait:false;"
+                + "semaphore 'waitForChild1';"
+                + "semaphore 'waitForChild2';"
+                + "def downstreams = downstreamBuilds().collect {it.projectName};"
+                + "assert downstreams == ['child1','child2']",
+            true));
+
+    j.buildAndAssertSuccess(parent);
+    SemaphoreStep.success("waitForParent/1", null);
+    SemaphoreStep.success("waitForParent/2", null);
+  }
+
+  @Test
+  public void withGrandchild() throws Exception {
+    WorkflowJob grandchild = j.createProject(WorkflowJob.class, "grandchild");
+    grandchild.setDefinition(new CpsFlowDefinition("", true));
+
+    WorkflowJob child = j.createProject(WorkflowJob.class, "child");
+    child.setDefinition(new CpsFlowDefinition("build 'grandchild'", true));
+
+    WorkflowJob parent = j.createProject(WorkflowJob.class);
+    parent.setDefinition(
+        new CpsFlowDefinition(
+            "def childBuild = build 'child';"
+                + "assert downstreamBuilds(run:childBuild).collect {it.projectName} == ['grandchild']",
+            true));
+
+    j.buildAndAssertSuccess(parent);
+  }
+}


### PR DESCRIPTION
The new pipeline step downstreamBuilds provides mechanism for getting downstream builds of current build (default) or for other build by providing a reference to its build wrapper.