### PR TITLE
Add help text for downstreamBuils step

### DIFF
--- a/src/main/resources/com/axis/system/jenkins/plugins/downstream/cache/pipeline/DownstreamBuildsStep/help.html
+++ b/src/main/resources/com/axis/system/jenkins/plugins/downstream/cache/pipeline/DownstreamBuildsStep/help.html
@@ -1,0 +1,12 @@
+<div>
+    <p>
+        Provides a list of all downstream builds for the provided build. If no
+        build is provided, then current build is used.
+    </p>
+    <p>
+        <b>Note:</b> If the downstream cache recently has been cleaned, or
+        Jenkins recently has been restarted, then this method might give
+        incomplete results! This behaviour might change in the future, without
+        prior notice.
+    </p>
+</div>


### PR DESCRIPTION
I didn't add any config.xml since the only parameter to the step is a
RunWrapper, which is hard to visualize/provide through an input box.
So only the help text should be sufficient. Also added a note about
incomplete return value if the cache isn't fully initiated at the time
of call.