### PR TITLE
Make GC opt-in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.axis.system.jenkins.plugins.downstream</groupId>
@@ -17,7 +18,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>3.47</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <build>
@@ -128,4 +129,10 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>


### PR DESCRIPTION
Using GC will load all upstream builds into memory. This messes
seriously with Jenkins memory management, since builds are supposed
to be lazy loaded only when needed.

Builds should not really need to be GCed at all, but in some
circumstances there may be orphan builds referenced in the
BuildCache. This happens *really* rarely and running a build cache
GC is most often way overkill.

Also worth noting is that all keys (and corresponding values) are
stored as Strings, so full builds will not be kept in memory even
if some orphan builds are still in the BuildCache.

To enable GC again, set the following system property to "true":
com.axis.system.jenkins.plugins.downstream.cache.BuildCache.GC_ENABLED

Some smaller fixes to get rid of IDEA warnings was also included
into this change.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
