### PR TITLE
Specifically ignore rebuild causes instead of identical projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
+      <artifactId>rebuild</artifactId>
+      <version>1.31</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
       <version>2.19</version>

--- a/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
+++ b/src/main/java/com/axis/system/jenkins/plugins/downstream/cache/BuildCache.java
@@ -146,6 +146,12 @@ public class BuildCache {
     List<Run> upstreamBuilds = new ArrayList<>();
     for (Cause cause : causeAction.getCauses()) {
       if (cause instanceof Cause.UpstreamCause) {
+        if (Jenkins.get().getPlugin("rebuild") != null) {
+          if (cause instanceof com.sonyericsson.rebuild.RebuildCause) {
+            // Ignore rebuild causes
+            continue;
+          }
+        }
         Cause.UpstreamCause upstreamCause = (Cause.UpstreamCause) cause;
 
         Job upstreamJob =
@@ -206,9 +212,7 @@ public class BuildCache {
       List<Run> upstreamBuilds = getUpstreamBuilds(causeAction);
 
       for (Run upstreamBuild : upstreamBuilds) {
-        // We check for identical parents since Rebuilder-plugin defines the retriggered build as
-        // upstream cause, which can lead to some strange side effects in the visualization.
-        if (upstreamBuild == null || upstreamBuild.getParent() == downstreamRun.getParent()) {
+        if (upstreamBuild == null) {
           continue;
         }
         Set<String> downstreamBuilds =


### PR DESCRIPTION
This adds a specific check if the build's cause was a "rebuild" cause, which replaces the previous "upstream project is same as current project" check. This means that a job that legitimately triggers a build of itself (like maybe some kind of parameterized "pipeline of pipelines" job) can now be tracked correctly.

The dependency on the [rebuild plugin](https://plugins.jenkins.io/rebuild/) is optional, the check is only performed if the plugin is activated.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

